### PR TITLE
support github issue labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ message = "webmailer error mail"
 
 [example.rules.normal_log.action.git]
 repo = "example/fuu"
+labels = "label1,label2"
 
 [example.rules.normal_log.action.exec_cmd]
 cmd = "/path/to/other_command.rb"

--- a/lib/popper/action/git.rb
+++ b/lib/popper/action/git.rb
@@ -3,10 +3,14 @@ require 'octokit'
 module Popper::Action
   class Git < Base
     def self.task(mail, params={})
+      issue_options = {}
+      issue_options[:labels] = @action_config.labels if @action_config.labels
+
       url = octkit.create_issue(
         @action_config.repo,
         mail.subject,
-        mail.utf_body
+        mail.utf_body,
+        issue_options
       )
       params["#{action_name}_url".to_sym] = url[:html_url] if url
       params

--- a/spec/fixture/popper_run.conf
+++ b/spec/fixture/popper_run.conf
@@ -20,6 +20,7 @@ body = [".*account_default_condition.*"]
 [example.default.action.git]
 token = "account_default_action"
 repo = "example/account_rule_action_git"
+labels = "first_gh_label,second_gh_label"
 
 [example.rules.foo.condition]
 subject = [".*account_rule_condition_subject.*"]
@@ -29,6 +30,7 @@ body = [".*account_rule_condition_body.*"]
 token = "account_rule_action_ghe"
 url = "https://account_rule_action_ghe"
 repo = "example/account_rule_action_ghe"
+labels = "first_ghe_label,second_ghe_label"
 
 [example.rules.foo.action.exec_cmd]
 cmd = "test_command"

--- a/spec/lib/mail_account_spec.rb
+++ b/spec/lib/mail_account_spec.rb
@@ -19,11 +19,11 @@ describe Popper::MailAccount do
 
       ## exec command
       expect_any_instance_of(Object).to receive(:system).with(
-        "test_command",
-        "default_condition account_rule_condition_subject",
-        "account_default_condition account_rule_condition_body\n",
-        "no-reply@example.com",
-        "example@example.com",
+        "test_command " \
+        "'default_condition account_rule_condition_subject' " \
+        "'account_default_condition account_rule_condition_body\n' " \
+        "'no-reply@example.com' " \
+        "'example@example.com'"
       ).and_return(true)
 
       # slack

--- a/spec/lib/mail_account_spec.rb
+++ b/spec/lib/mail_account_spec.rb
@@ -44,7 +44,8 @@ describe Popper::MailAccount do
       allow_any_instance_of(Octokit::Client).to receive(:create_issue).with(
         "example/account_rule_action_git",
         "default_condition account_rule_condition_subject",
-        "account_default_condition account_rule_condition_body\n"
+        "account_default_condition account_rule_condition_body\n",
+        { labels: "first_gh_label,second_gh_label" }
       ).and_return(
         { html_url: "https://test.git.com/v3/issues/#123" }
       )
@@ -53,7 +54,8 @@ describe Popper::MailAccount do
       allow_any_instance_of(Octokit::Client).to receive(:create_issue).with(
         "example/account_rule_action_ghe",
         "default_condition account_rule_condition_subject",
-        "account_default_condition account_rule_condition_body\n"
+        "account_default_condition account_rule_condition_body\n",
+        { labels: "first_ghe_label,second_ghe_label" }
       ).and_return(
         { html_url: "https://test.ghe.com/v3/issues/#123" }
       )


### PR DESCRIPTION
support github issue labels.
add config `labels`, it's comma separated label names.

```
[example.rules.normal_log.action.git]
repo = "example/fuu"
labels = "label1,label2"
```

when label name is not found in repo, create label (octokit automation).
