### PR TITLE
Enable to limit the number of lines in the mail body when notifying slack.

### DIFF
--- a/lib/popper/action/slack.rb
+++ b/lib/popper/action/slack.rb
@@ -14,7 +14,7 @@ module Popper::Action
         title: mail.subject,
         color: "good"
       }
-      note[:text] = mail.utf_body if @action_config.use_body
+      note[:text] = mail_body(mail.utf_body) if @action_config.use_body
 
       body = @action_config.message || "popper mail notification"
       body += " #{@action_config.mentions.join(" ")}" if @action_config.mentions
@@ -33,5 +33,12 @@ module Popper::Action
       @action_config.respond_to?(:webhook_url)
     end
 
+    def self.mail_body(body)
+      if @action_config.use_body.kind_of?(Integer) && body.lines.length > @action_config.use_body
+        return body.lines[0, @action_config.use_body].push('--- snip ---').join
+      end
+
+      body
+    end
   end
 end


### PR DESCRIPTION
- Sometimes there are too many email body.
- In many cases, the first part of the email is all that is needed to understand the content.